### PR TITLE
CI: move CI to github

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -23,12 +23,12 @@ jobs:
     steps:
     - name: Get PR Commits
       id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@198af03
+      uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check that all commits are signed-off
-      uses: tim-actions/dco@f2279e6
+      uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,7 +107,7 @@ jobs:
     steps:
       - name: Get PR commits
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@198af03
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -125,7 +125,7 @@ jobs:
 
           ZAZA_TAG="Func-test-pr: "
           FUNC_PR=$(jq -r '.[].commit.message' <<< "$COMMIT_DATA" | grep -i "^${ZAZA_TAG}" | tail -1)
-          PR_URL=$($(echo $FUNC_PR | sed -e "s/^$ZAZA_TAG//I"))
+          PR_URL=$(echo $FUNC_PR | sed -e "s/^$ZAZA_TAG//I")
 
           echo "zaza_pr=$PR_URL" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -186,6 +186,7 @@ jobs:
       - name: Generate crash dumps
         if: failure()
         run: |
+          sudo snap install --classic juju-crashdump
           models=$(juju models | grep zaza | awk '{print $1}' | tr -d '*')
           rm -rf ./crashdumps
           mkdir ./crashdumps

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,13 +12,13 @@ parts:
     - python3-dev
     - libffi-dev
     - libssl-dev
-    - rustc-1.76
-    - cargo-1.76
+    - rustc-1.80
+    - cargo-1.80
     - pkg-config
     override-build: |
-      # Note(mylesjp): Force build to use rustc-1.76
-      ln -s /usr/bin/rustc-1.76 /usr/bin/rustc
-      ln -s /usr/bin/cargo-1.76 /usr/bin/cargo
+      # Note(mylesjp): Force build to use rustc-1.80
+      ln -s /usr/bin/rustc-1.80 /usr/bin/rustc
+      ln -s /usr/bin/cargo-1.80 /usr/bin/cargo
       craftctl default
     build-snaps:
     - charm/latest/edge

--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -9,7 +9,7 @@ options:
   basic:
     use_venv: True
     include_system_packages: False
-repo: https://opendev.org/x/charm-ovn-chassis
+repo: https://github.com/canonical/charm-ovn-chassis.git
 config:
   deletes:
     - source

--- a/src/tests/bundles/noble-caracal.yaml
+++ b/src/tests/bundles/noble-caracal.yaml
@@ -20,19 +20,11 @@ applications:
       source: *openstack-origin
     channel: latest/edge
 
-  magpie:
-    # By default, when instance NUMA placement is not specified,
-    # a topology of N sockets, each with one core and one thread,
-    # is used for an instance, where N corresponds to the number of
-    # instance vCPUs requested.
-    #
-    # Let's use a 8 VCPU 2 socket flavor for low level tests
-    constraints: "instance-type=twosocketm1.xlarge"
-    charm: ch:magpie
+  ubuntu:
+    charm: ch:ubuntu
     num_units: 2
-    options:
-      source: *openstack-origin
     channel: latest/edge
+    constraints: "virt-type=virtual-machine mem=8G"
 
   ovn-chassis:
     charm: ../../../ovn-chassis_amd64.charm
@@ -42,7 +34,7 @@ relations:
   - - 'ovn-central:certificates'
     - 'vault:certificates'
 
-  - - 'magpie:juju-info'
+  - - 'ubuntu:juju-info'
     - 'ovn-chassis:juju-info'
 
   - - 'ovn-chassis:ovsdb'

--- a/src/tests/tests.yaml
+++ b/src/tests/tests.yaml
@@ -10,8 +10,8 @@ dev_bundles:
 - noble-caracal
 
 target_deploy_status:
-  magpie:
-    workload-status-message: icmp ok
+  ubuntu:
+    workload-status-message: ""
   ovn-central:
     workload-status: waiting
     workload-status-message-prefix: "'ovsdb-peer' incomplete, 'certificates' awaiting server certificate data"
@@ -29,10 +29,10 @@ configure:
 - zaza.openstack.charm_tests.neutron.setup.undercloud_and_charm_setup
 
 configure_options:
-  # magpie is obviously not a hypervisor, but for the purpose of this charm
+  # ubuntu is obviously not a hypervisor, but for the purpose of this charm
   # gate it is the principal charm for ovn-chassis and as such is the target
   # unit for preparing hugepages and VFIO configuration.
-  hypervisor_application: 'magpie'
+  hypervisor_application: 'ubuntu'
 
 tests:
 - zaza.openstack.charm_tests.ovn.tests.OVNChassisDeferredRestartTest

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -18,6 +18,7 @@ skip_missing_interpreters = False
 skip_install = True
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
+         TEST_JUJU3=true
 allowlist_externals = juju
 passenv =
     HOME
@@ -25,7 +26,9 @@ passenv =
     CS_*
     OS_*
     TEST_*
-deps = -r{toxinidir}/test-requirements.txt
+deps =
+    -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-noble.txt}
+    -r{toxinidir}/test-requirements.txt
 
 [testenv:pep8]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands = stestr run --slowest {posargs}
 
 [testenv:pep8]
 basepython = python3
-deps = flake8==3.9.2
+deps = flake8==7.1.1
        git+https://github.com/juju/charm-tools.git
 commands = flake8 {posargs} src unit_tests \
     {toxinidir}/src/files/nagios/nrpe_check_ovn_certs.py \


### PR DESCRIPTION
This PR facilitates move from opendev to github. It fixes various issues that were broken with the building/linting/unit testing/functional testing. It also contains new github workflows that will take over functionality of the old CI system.

Please review individual commits.