### PR TITLE
CI: Add github workflows.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @canonical/ovn-team

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,0 +1,48 @@
+name: Commits
+on:
+  - pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    name: Canonical CLA signed
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v2
+
+  dco-check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read  # for tim-actions/get-pr-commits to get list of commits from the PR
+    name: Signed-off-by (DCO)
+    steps:
+    - name: Get PR Commits
+      id: 'get-pr-commits'
+      uses: tim-actions/get-pr-commits@198af03
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check that all commits are signed-off
+      uses: tim-actions/dco@f2279e6
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+
+  signed-commits-check:
+    runs-on: ubuntu-latest
+    name: Check signed commits in PR
+    permissions:
+      contents: read
+      # Note that the action authors suggest using `on: pull_request_target`
+      # and write permissions so that the action can comment on the PR.
+      #
+      # However, I found that doing that made the job not run on subsequent
+      # updates to the PR, which is not what we want.
+      pull-requests: read
+    steps:
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,202 @@
+name: Tests
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt install tox
+
+      - name: Run linter
+        run: |
+          tox -e pep8
+
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt install tox
+
+      - name: Run Unit tests
+        run: |
+          tox -e py3
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt install tox
+
+      - name: Run coverage
+        run: |
+          tox -e cover
+
+  build:
+    name: Build charm
+    needs:
+      - lint
+      - unit
+      - coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt install tox
+          sudo snap install charmcraft --channel 3.x/stable --classic
+          sudo snap install lxd --channel 5.21/stable
+          sudo snap set lxd daemon.group=adm
+          sudo lxd init --auto
+
+      - name: Clear FORWARD firewall rules
+        run: |
+          # Docker can inject rules causing firewall conflicts
+          sudo iptables -P FORWARD ACCEPT  || true
+          sudo ip6tables -P FORWARD ACCEPT || true
+          sudo iptables -F FORWARD  || true
+          sudo ip6tables -F FORWARD || true
+
+      - name: Build charm
+        run: |
+          tox -e build
+
+      - name: Store charm as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ovn-chassis-charm
+          path: ./ovn-chassis_amd64.charm
+          retention-days: 7
+
+  parse_tags:
+    name: Parse tags in PR commits
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      zaza_pr: ${{ steps.find-zaza-pr.outputs.zaza_pr }}
+      
+    steps:
+      - name: Get PR commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@198af03
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Find requested functional test PR
+        id: 'find-zaza-pr'
+        run: |
+          # Note(mkalcok): The command below cleanely transfers data from Github
+          #                variable to bash variable without interpreting curly
+          #                braces or losing quotations.
+          COMMIT_DATA=$(
+          cat <<'EOF'
+          ${{ steps.get-pr-commits.outputs.commits }}
+          EOF
+          )
+
+          ZAZA_TAG="Func-test-pr: "
+          FUNC_PR=$(jq -r '.[].commit.message' <<< "$COMMIT_DATA" | grep -i "^${ZAZA_TAG}" | tail -1)
+          PR_URL=$($(echo $FUNC_PR | sed -e "s/^$ZAZA_TAG//I"))
+
+          echo "zaza_pr=$PR_URL" >> "$GITHUB_OUTPUT"
+
+  functest:
+    name: Functional Tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - parse_tags
+    strategy:
+      matrix:
+        bundle: ["noble-caracal"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+ 
+      - name: Download built charm
+        uses: actions/download-artifact@v4
+        with:
+          name: ovn-chassis-charm
+ 
+      - name: Install dependencies
+        run: |
+          sudo apt install tox
+          sudo snap install concierge --classic
+ 
+      - name: Prepare Environment for functional tests
+        run: |
+          # Use concierge to setup LXD and bootstrap juju container
+          sudo concierge prepare -p machine
+          # Create second bridged network needed by the functional tests
+          lxc network create second --type=bridge
+ 
+      - name: Install custom functional test repository
+        if: ${{ needs.parse_tags.outputs.zaza_pr != '' }}
+        working-directory: ./src/
+        env:
+          ZAZA_PR: ${{ needs.parse_tags.outputs.zaza_pr }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tox -e func-target --notest
+
+          gh pr view --json headRepositoryOwner,headRepository,headRefName "$ZAZA_PR" > /tmp/zaza-pr.json
+          PR_OWNER=$(cat /tmp/zaza-pr.json | jq -r '.headRepositoryOwner.login')
+          PR_REPO=$(cat /tmp/zaza-pr.json | jq -r '.headRepository.name')
+          PR_BRANCH=$(cat /tmp/zaza-pr.json | jq -r '.headRefName')
+          PR_REPO_URL=$(gh repo view --json url --jq '.url' $PR_OWNER/$PR_REPO)
+
+          source .tox/func-target/bin/activate
+          pip install --force-reinstall --no-deps git+"$PR_REPO_URL"@"$PR_BRANCH"
+          
+
+      - name: Run functional tests for bundle ${{ matrix.bundle }}
+        working-directory: ./src/
+        run: |
+          tox -e func-target -- ${{ matrix.bundle }}
+
+      - name: Generate crash dumps
+        if: failure()
+        run: |
+          models=$(juju models | grep zaza | awk '{print $1}' | tr -d '*')
+          rm -rf ./crashdumps
+          mkdir ./crashdumps
+          for model in $models; do
+            juju-crashdump -m $model -o ./crashdumps
+          done
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crashdumps-${{ matrix.bundle }}
+          path: "./crashdumps/*"
+


### PR DESCRIPTION
I suspect that the workflows need to be first "blindly" merged into the default branch, otherwise the github is not picking up on them. When this commit was a part of #2, github would not run any workflows.


This set of changes adds github CI workflows including:
* Default canonical checks for signed CLA, signed and signed-off commits
* linting
* unit tests
* coverage
* charm build
* functional tests