### PR TITLE
github: Default branch changed to 'main'.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Tests
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
As part of switching over to `main` as a default branch, we need just a small update to the CI workflows.