### PR TITLE
tox: Use ZAZA_FEATURE_BUG472 in tests.

### DIFF
--- a/src/tox.ini
+++ b/src/tox.ini
@@ -15,10 +15,15 @@ skip_missing_interpreters = False
 # We use tox mainly for virtual environment management for test requirements
 # and do not install the charm code as a Python package into that environment.
 # Ref: https://tox.wiki/en/latest/config.html#skip_install
+#
+# Note(mkalcok): Environment variable 'ZAZA_FEATURE_BUG472' needs to be set
+# for functional tests to correctly get unit's public IP address.
+# Ref: https://github.com/openstack-charmers/zaza/issues/472
 skip_install = True
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
          TEST_JUJU3=true
+         ZAZA_FEATURE_BUG472=1
 allowlist_externals = juju
 passenv =
     HOME
@@ -26,6 +31,7 @@ passenv =
     CS_*
     OS_*
     TEST_*
+    ZAZA_*
 deps =
     -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-noble.txt}
     -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
This environment variable allows functional tests to correctly get unit's IP addres.