### PR TITLE
NO MERGE: Test using binary wheels for charm build

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,7 +5,7 @@ parts:
     source: src/
     plugin: reactive
     reactive-charm-build-arguments:
-    - --binary-wheels-from-source
+    - --binary-wheels
     - -v
     build-packages:
     - git


### PR DESCRIPTION
This may improve our build time in CI which currently hovers around 15 mins. Perhaps by opting to NOT build our dependencies from source, we could improve that time.

Even if this change is effective, we will have to ensure that the option is used only in dev/ci environments and not when building charm for publishing.