### PR TITLE
func-tests: COS integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
       pull-requests: read
     outputs:
       zaza_pr: ${{ steps.find-zaza-pr.outputs.zaza_pr }}
-      
+
     steps:
       - name: Get PR commits
         id: 'get-pr-commits'
@@ -131,13 +131,15 @@ jobs:
 
   functest:
     name: Functional Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, large, noble]
     needs:
       - build
       - parse_tags
     strategy:
       matrix:
         bundle: ["noble-caracal"]
+    env:
+      DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -149,16 +151,43 @@ jobs:
  
       - name: Install dependencies
         run: |
-          sudo apt install tox
+          sudo apt -yqq install tox
           sudo snap install concierge --classic
+          sudo snap install juju-wait --classic
  
       - name: Prepare Environment for functional tests
         run: |
-          # Use concierge to setup LXD and bootstrap juju container
-          sudo concierge prepare -p machine
+          # Use concierge to setup LXD, microk8s and bootstrap juju controller
+          cat <<EOF >>/tmp/concierge.yaml
+          juju:
+            channel: 3.5/stable
+
+          providers:
+            microk8s:
+              enable: true
+              bootstrap: false
+              addons:
+                - dns
+                - hostpath-storage
+                - metallb
+
+            lxd:
+              enable: true
+              bootstrap: true
+          EOF
+
+          sudo concierge prepare -c /tmp/concierge.yaml
+
           # Create second bridged network needed by the functional tests
           lxc network create second --type=bridge
- 
+
+          # Add microk8s as a kubernetes substrate to the Juju controller
+          sudo microk8s status --wait
+          # The kubernetes API is not always immediately available to use, even if
+          # microk8s status reports ready state. These retries ensure that we don't
+          # fail the test unnecessarily
+          (r=30;while ! juju add-k8s mk8s --controller concierge-lxd ; do ((--r))||exit;sleep 2;done)
+
       - name: Install custom functional test repository
         if: ${{ needs.parse_tags.outputs.zaza_pr != '' }}
         working-directory: ./src/
@@ -176,7 +205,14 @@ jobs:
 
           source .tox/func-target/bin/activate
           pip install --force-reinstall --no-deps git+"$PR_REPO_URL"@"$PR_BRANCH"
-          
+
+      - name: Deploy COS lite bundle
+        working-directory: ./src/tests/bundles/
+        run: |
+          juju add-model cos-lite mk8s
+          juju deploy ./cos-lite.yaml --trust --overlay ./offers-overlay.yaml
+          juju-wait -v
+          juju status
 
       - name: Run functional tests for bundle ${{ matrix.bundle }}
         working-directory: ./src/

--- a/src/tests/bundles/cos-lite.yaml
+++ b/src/tests/bundles/cos-lite.yaml
@@ -1,0 +1,31 @@
+---
+bundle: kubernetes
+name: cos-lite
+description: >
+  COS Lite is a light-weight, highly-integrated, observability stack running on Kubernetes
+applications:
+  traefik:
+    charm: traefik-k8s
+    scale: 1
+    trust: true
+    channel: stable
+  prometheus:
+    charm: prometheus-k8s
+    scale: 1
+    trust: true
+    channel: stable
+  grafana:
+    charm: grafana-k8s
+    scale: 1
+    trust: true
+    channel: stable
+
+relations:
+- [traefik:ingress-per-unit, prometheus:ingress]
+- [traefik:traefik-route, grafana:ingress]
+- [grafana:grafana-source, prometheus:grafana-source]
+# COS-monitoring
+- [prometheus:metrics-endpoint, traefik:metrics-endpoint]
+- [prometheus:metrics-endpoint, grafana:metrics-endpoint]
+- [grafana:grafana-dashboard, prometheus:grafana-dashboard]
+

--- a/src/tests/bundles/noble-caracal.yaml
+++ b/src/tests/bundles/noble-caracal.yaml
@@ -26,6 +26,11 @@ applications:
     channel: latest/edge
     constraints: "virt-type=virtual-machine mem=8G"
 
+  grafana-agent:
+    charm: ch:grafana-agent
+    channel: latest/stable
+    base: ubuntu@24.04
+
   ovn-chassis:
     charm: ../../../ovn-chassis_amd64.charm
 
@@ -42,3 +47,9 @@ relations:
 
   - - 'ovn-chassis:certificates'
     - 'vault:certificates'
+
+  - - 'grafana-agent:juju-info'
+    - 'ubuntu:juju-info'
+
+  - - 'grafana-agent:cos-agent'
+    - 'ovn-chassis:cos-agent'

--- a/src/tests/bundles/offers-overlay.yaml
+++ b/src/tests/bundles/offers-overlay.yaml
@@ -1,0 +1,11 @@
+applications:
+  grafana:
+    offers:
+      grafana-dashboards:
+        endpoints:
+          - grafana-dashboard
+  prometheus:
+    offers:
+      prometheus-receive-remote-write:
+        endpoints:
+        - receive-remote-write

--- a/src/tests/tests.yaml
+++ b/src/tests/tests.yaml
@@ -21,12 +21,16 @@ target_deploy_status:
   vault:
     workload-status: blocked
     workload-status-message-prefix: Vault needs to be initialized
+  grafana-agent:
+    workload-status: blocked
+    workload-status-message-prefix: ""
 
 # Note that full end to end tests are performed with OVN in the
 # neutron-api-plugin-ovn and octavia charm gates
 configure:
 - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation
 - zaza.openstack.charm_tests.neutron.setup.undercloud_and_charm_setup
+- zaza.openstack.charm_tests.cos.setup.try_relate_to_cos
 
 configure_options:
   # ubuntu is obviously not a hypervisor, but for the purpose of this charm
@@ -37,5 +41,6 @@ configure_options:
 tests:
 - zaza.openstack.charm_tests.ovn.tests.OVNChassisDeferredRestartTest
 - zaza.openstack.charm_tests.ovn.tests.ChassisCharmOperationTest
+- zaza.openstack.charm_tests.ovn.tests.ChassisCosIntegrationTest
 - zaza.openstack.charm_tests.ovn.tests.DPDKTest
 


### PR DESCRIPTION
Functional tests were extended to verify integration of ovn-chassis charm with COS via grafana-agent.

Included cos-lite bundle is expected to be deployed on the same controller, in a separate model, on top of kubernetes substrate. It provides cross-model relation offers that grafana-agent connects to.

Inclusion of the second model and the necessity to run kubernetes were causing Github runners to run out of disk space, therefore this change also moves the execution of functional tests to the self-hosted runners.
