### PR TITLE
CI: Resolve Juju 3.5 and rust dependency issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,7 @@ jobs:
           # Use concierge to setup LXD, microk8s and bootstrap juju controller
           cat <<EOF >>/tmp/concierge.yaml
           juju:
-            channel: 3.5/stable
+            channel: 3.6/stable
 
           providers:
             microk8s:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,8 +12,8 @@ parts:
     - python3-dev
     - libffi-dev
     - libssl-dev
-    - rustc-1.80
-    - cargo-1.80
+    - rustc-1.85
+    - cargo-1.85
     - pkg-config
     override-build: |
       # Note(mylesjp): Force build to use rustc-1.80

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,9 +7,11 @@ pyparsing<3.0.0  # aodhclient is pinned in zaza and needs pyparsing < 3.0.0, but
 
 stestr>=2.2.0
 
-# Dependency of stestr. Workaround for
-# https://github.com/mtreinish/stestr/issues/145
-cliff<3.0.0
+# Charmhelpers depend on 'distutils' which has been deprecated since python3.12 [0],
+# but can be substituted with setuptools.
+#
+# [0] https://docs.python.org/3.12/library/distutils.html
+setuptools
 
 requests>=2.18.4
 charms.reactive


### PR DESCRIPTION
This PR contains a bunch of commits that collectively unblock our charm builds/CI:

* unpin cliff to avoid usage of deprecated pkg_resources
* use Juju 3.6 for CI since 3.5 is no longer avialable
* use rustc-1.85 build dependency to support building some of the python packages from source.
