### PR TITLE
[stable/24.03] CI: Resolve Juju 3.4 and rust dependency issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,7 +190,7 @@ jobs:
           # Use concierge to setup LXD, microk8s and bootstrap juju controller
           cat <<EOF >>/tmp/concierge.yaml
           juju:
-            channel: 3.4/stable
+            channel: 3.6/stable
 
           providers:
             microk8s:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,8 +12,8 @@ parts:
       - python3-dev
       - libffi-dev
       - libssl-dev
-      - rustc
-      - cargo
+      - rustc-1.85
+      - cargo-1.85
     build-snaps:
       - charm
     build-environment:

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -8,9 +8,11 @@ setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb
 
 stestr>=2.2.0
 
-# Dependency of stestr. Workaround for
-# https://github.com/mtreinish/stestr/issues/145
-cliff<3.0.0
+# Charmhelpers depend on 'distutils' which has been deprecated since python3.12 [0],
+# but can be substituted with setuptools.
+#
+# [0] https://docs.python.org/3.12/library/distutils.html
+setuptools
 
 requests>=2.18.4
 charms.reactive


### PR DESCRIPTION
Backport of #16 

---

This PR contains a bunch of commits that collectively unblock our charm builds/CI:

* unpin cliff to avoid usage of deprecated pkg_resources
* use Juju 3.6 for CI since 3.4 is no longer available
* use rustc-1.85 build dependency to support building some of the python packages from source.