### PR TITLE
build.lock: Update charm-layer-ovn (24.03) to include ovn-monitor-all

### DIFF
--- a/src/build.lock
+++ b/src/build.lock
@@ -45,8 +45,8 @@
       "item": "layer:ovn",
       "url": "https://github.com/openstack-charmers/charm-layer-ovn.git",
       "vcs": null,
-      "branch": "ac00157ce05865911c2249072a342681334285c6",
-      "commit": "ac00157ce05865911c2249072a342681334285c6"
+      "branch": "b0cee1d3b1bf7e7fc4236d9b2057419d3411771b",
+      "commit": "b0cee1d3b1bf7e7fc4236d9b2057419d3411771b"
     },
     {
       "type": "layer",

--- a/src/lib/charm/openstack/ovn_chassis.py
+++ b/src/lib/charm/openstack/ovn_chassis.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 
-from charmhelpers.core.host import rsync, write_file
+from charmhelpers.core.host import cmp_pkgrevno, rsync, write_file
 from charmhelpers.contrib.charmsupport import nrpe
 import charmhelpers.fetch as ch_fetch
 
@@ -51,6 +52,33 @@ class OVNChassisCharm(charms.ovn_charm.DeferredEventMixin,
     @property
     def packages(self):
         return super().packages + self.nrpe_packages
+
+    def dpdk_eal_allow_devices(self, devices):
+        """Build EAL command line argument for allowed devices.
+
+        Guard against the dpdk package not being installed yet when
+        cmp_pkgrevno is called, which causes an AttributeError.
+
+        :param devices: PCI devices for use by DPDK
+        :type devices: collections.OrderedDict[str,Tuple[str,str]]
+        :returns: Command line arguments for use with DPDK EAL.
+        :rtype: str
+        """
+        try:
+            if cmp_pkgrevno('dpdk', '20.11.3') >= 0:
+                flag = '-a'
+            else:
+                flag = '-w'
+        except (AttributeError, TypeError):
+            logging.warning(
+                'dpdk package is not yet installed, defaulting to '
+                '-a flag for EAL allow devices')
+            flag = '-a'
+
+        return ' '.join([
+            flag + ' ' + device
+            for device in devices
+        ])
 
     def render_nrpe(self):
         hostname = nrpe.get_nagios_hostname()


### PR DESCRIPTION
This PR adds support for ovn-monitor-all in ovn-controller and fixes a DPDK configuration crash when the dpdk package is not yet installed.

Related-Bug: LP 2138758