### PR TITLE
build.lock: Update charm-layer-ovn (23.03) to include ovn-monitor-all

### DIFF
--- a/src/build.lock
+++ b/src/build.lock
@@ -46,7 +46,7 @@
       "url": "https://github.com/openstack-charmers/charm-layer-ovn.git",
       "vcs": null,
       "branch": "refs/heads/stable/23.03",
-      "commit": "b08c4e147ccb26cb6ee898b552aec1cee4b4f353"
+      "commit": "6a267aadd54c8b1d6833e7414133cc440806d95d"
     },
     {
       "type": "layer",


### PR DESCRIPTION
New version of charm-layer-ovn (23.03) that adds the ovn-monitor-all configuration option to the ovn-controller.

Related-Bug: LP 2138758
Signed-off-by: goldberl <leah.goldberg@canonical.com>