### PR TITLE
enforce ovn-controller log perms for rsyslog

### DIFF
--- a/src/lib/charm/openstack/ovn_chassis.py
+++ b/src/lib/charm/openstack/ovn_chassis.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import os
+import subprocess
 
-from charmhelpers.core.host import rsync, write_file
+from charmhelpers.core.host import rsync, service_restart, write_file
 from charmhelpers.contrib.charmsupport import nrpe
 import charmhelpers.fetch as ch_fetch
 
@@ -26,6 +27,17 @@ NAGIOS_PLUGINS = '/usr/local/lib/nagios/plugins'
 SCRIPTS_DIR = '/usr/local/bin'
 CERTCHECK_CRONFILE = '/etc/cron.d/ovn-chassis-cert-checks'
 CRONJOB_CMD = "{schedule} root {command} 2>&1 | logger -p local0.notice\n"
+OVN_COMMON_LOGROTATE = '/etc/logrotate.d/ovn-common'
+OVN_CONTROLLER_SYSTEMD_DROPIN_DIR = \
+    '/etc/systemd/system/ovn-controller.service.d'
+OVN_CONTROLLER_SYSTEMD_DROPIN_FILE = \
+    '{}/log-perms.conf'.format(OVN_CONTROLLER_SYSTEMD_DROPIN_DIR)
+OVN_CONTROLLER_SYSTEMD_DROPIN_CONTENT = """[Service]
+ExecStartPre=/usr/bin/mkdir -p /var/log/ovn
+ExecStartPre=/usr/bin/touch /var/log/ovn/ovn-controller.log
+ExecStartPost=/usr/bin/chown root:adm /var/log/ovn/ovn-controller.log
+ExecStartPost=/usr/bin/chmod 0640 /var/log/ovn/ovn-controller.log
+"""
 
 
 charm.use_defaults('charm.default-select-release')
@@ -78,3 +90,59 @@ class OVNChassisCharm(charms.ovn_charm.DeferredEventMixin,
             schedule='*/15 * * * *',
             command=dst)
         write_file(CERTCHECK_CRONFILE, cronjob)
+
+    def configure_ovn_controller_log_permissions(self):
+        """Ensure ovn-controller log file permissions remain rsyslog readable.
+
+        This applies two safeguards:
+        1) add ``create 0640 root adm`` before ``postrotate`` in
+           ``/etc/logrotate.d/ovn-common`` (if missing)
+        2) install a systemd drop-in for ``ovn-controller`` to enforce
+           log permissions on service start.
+        """
+        self._ensure_ovn_common_logrotate_create()
+        if self._ensure_ovn_controller_dropin():
+            subprocess.call(['systemctl', 'daemon-reload'])
+            service_restart('ovn-controller')
+
+    def _ensure_ovn_common_logrotate_create(self):
+        """Add ``create 0640 root adm`` before ``postrotate`` if missing."""
+        if not os.path.exists(OVN_COMMON_LOGROTATE):
+            return False
+
+        with open(OVN_COMMON_LOGROTATE) as fd:
+            content = fd.read()
+
+        if 'create 0640 root adm' in content:
+            return False
+
+        lines = content.splitlines(True)
+        for idx, line in enumerate(lines):
+            if line.strip().startswith('postrotate'):
+                indent = line[:len(line) - len(line.lstrip())]
+                lines.insert(
+                    idx,
+                    '{}create 0640 root adm\n'.format(indent),
+                )
+                new_content = ''.join(lines)
+                write_file(OVN_COMMON_LOGROTATE, new_content, perms=0o644)
+                return True
+
+        return False
+
+    def _ensure_ovn_controller_dropin(self):
+        """Create / update ovn-controller systemd drop-in."""
+        os.makedirs(OVN_CONTROLLER_SYSTEMD_DROPIN_DIR, exist_ok=True)
+
+        if os.path.exists(OVN_CONTROLLER_SYSTEMD_DROPIN_FILE):
+            with open(OVN_CONTROLLER_SYSTEMD_DROPIN_FILE) as fd:
+                current = fd.read()
+            if current == OVN_CONTROLLER_SYSTEMD_DROPIN_CONTENT:
+                return False
+
+        write_file(
+            OVN_CONTROLLER_SYSTEMD_DROPIN_FILE,
+            OVN_CONTROLLER_SYSTEMD_DROPIN_CONTENT,
+            perms=0o644,
+        )
+        return True

--- a/src/reactive/ovn_chassis_handlers.py
+++ b/src/reactive/ovn_chassis_handlers.py
@@ -29,6 +29,14 @@ def configure_deferred_restarts():
         instance.configure_deferred_restarts()
 
 
+@reactive.when_not('is-update-status-hook')
+@reactive.when('config.rendered')
+def configure_ovn_controller_log_permissions():
+    """Ensure ovn-controller log file permissions are rsyslog readable."""
+    with charm.provide_charm_instance() as charm_instance:
+        charm_instance.configure_ovn_controller_log_permissions()
+
+
 @reactive.when_none('charm.paused', 'is-update-status-hook')
 @reactive.when('config.rendered')
 @reactive.when_any('config.changed.nagios_context',

--- a/unit_tests/test_lib_charm_openstack_ovn_chassis.py
+++ b/unit_tests/test_lib_charm_openstack_ovn_chassis.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import tempfile
+import unittest
+
+import mock
+
+
+charms = sys.modules['charms']
+charms.ovn_charm = mock.MagicMock()
+
+
+class _DeferredEventMixin(object):
+    pass
+
+
+class _BaseOVNChassisCharm(object):
+
+    @property
+    def packages(self):
+        return []
+
+    def render_nrpe(self):
+        return None
+
+
+charms.ovn_charm.DeferredEventMixin = _DeferredEventMixin
+charms.ovn_charm.BaseOVNChassisCharm = _BaseOVNChassisCharm
+sys.modules['charms.ovn_charm'] = charms.ovn_charm
+
+import lib.charm.openstack.ovn_chassis as ovn_chassis
+
+
+class TestOVNChassisCharmMethods(unittest.TestCase):
+
+    def setUp(self):
+        self.target = ovn_chassis.OVNChassisCharm.__new__(
+            ovn_chassis.OVNChassisCharm)
+
+    def test_configure_ovn_controller_log_permissions_restart_on_change(self):
+        with mock.patch.object(
+            self.target, '_ensure_ovn_common_logrotate_create'
+        ) as ensure_logrotate, mock.patch.object(
+            self.target,
+            '_ensure_ovn_controller_dropin',
+            return_value=True,
+        ) as ensure_dropin, mock.patch.object(
+            ovn_chassis.subprocess, 'call'
+        ) as subprocess_call, mock.patch.object(
+            ovn_chassis, 'service_restart'
+        ) as service_restart:
+            self.target.configure_ovn_controller_log_permissions()
+
+        ensure_logrotate.assert_called_once_with()
+        ensure_dropin.assert_called_once_with()
+        subprocess_call.assert_called_once_with(
+            ['systemctl', 'daemon-reload'])
+        service_restart.assert_called_once_with('ovn-controller')
+
+    def test_configure_ovn_controller_log_permissions_no_restart_no_change(self):  # noqa: E501
+        with mock.patch.object(
+            self.target, '_ensure_ovn_common_logrotate_create'
+        ) as ensure_logrotate, mock.patch.object(
+            self.target,
+            '_ensure_ovn_controller_dropin',
+            return_value=False,
+        ) as ensure_dropin, mock.patch.object(
+            ovn_chassis.subprocess, 'call'
+        ) as subprocess_call, mock.patch.object(
+            ovn_chassis, 'service_restart'
+        ) as service_restart:
+            self.target.configure_ovn_controller_log_permissions()
+
+        ensure_logrotate.assert_called_once_with()
+        ensure_dropin.assert_called_once_with()
+        subprocess_call.assert_not_called()
+        service_restart.assert_not_called()
+
+    def test_ensure_ovn_common_logrotate_create_adds_line(self):
+        with tempfile.TemporaryDirectory() as td:
+            logrotate_path = os.path.join(td, 'ovn-common')
+            with open(logrotate_path, 'w') as fd:
+                fd.write(
+                    '/var/log/ovn/ovn-controller.log {\n'
+                    '    daily\n'
+                    '    postrotate\n'
+                    '        /bin/true\n'
+                    '    endscript\n'
+                    '}\n')
+
+            with mock.patch.object(
+                ovn_chassis, 'OVN_COMMON_LOGROTATE', logrotate_path
+            ), mock.patch.object(ovn_chassis, 'write_file') as write_file:
+                changed = self.target._ensure_ovn_common_logrotate_create()
+
+            self.assertTrue(changed)
+            write_file.assert_called_once()
+            args, kwargs = write_file.call_args
+            self.assertEqual(args[0], logrotate_path)
+            self.assertIn('create 0640 root adm\n    postrotate', args[1])
+            self.assertEqual(kwargs.get('perms'), 0o644)
+
+    def test_ensure_ovn_common_logrotate_create_no_change_if_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            logrotate_path = os.path.join(td, 'ovn-common')
+            with open(logrotate_path, 'w') as fd:
+                fd.write(
+                    '/var/log/ovn/ovn-controller.log {\n'
+                    '    create 0640 root adm\n'
+                    '    postrotate\n'
+                    '        /bin/true\n'
+                    '    endscript\n'
+                    '}\n')
+
+            with mock.patch.object(
+                ovn_chassis, 'OVN_COMMON_LOGROTATE', logrotate_path
+            ), mock.patch.object(ovn_chassis, 'write_file') as write_file:
+                changed = self.target._ensure_ovn_common_logrotate_create()
+
+            self.assertFalse(changed)
+            write_file.assert_not_called()
+
+    def test_ensure_ovn_controller_dropin_writes_when_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            dropin_dir = os.path.join(td, 'ovn-controller.service.d')
+            dropin_file = os.path.join(dropin_dir, 'log-perms.conf')
+            with mock.patch.object(
+                ovn_chassis,
+                'OVN_CONTROLLER_SYSTEMD_DROPIN_DIR',
+                dropin_dir,
+            ), mock.patch.object(
+                ovn_chassis,
+                'OVN_CONTROLLER_SYSTEMD_DROPIN_FILE',
+                dropin_file,
+            ), mock.patch.object(ovn_chassis, 'write_file') as write_file:
+                changed = self.target._ensure_ovn_controller_dropin()
+
+            self.assertTrue(changed)
+            write_file.assert_called_once_with(
+                dropin_file,
+                ovn_chassis.OVN_CONTROLLER_SYSTEMD_DROPIN_CONTENT,
+                perms=0o644,
+            )
+
+    def test_ovn_controller_dropin_uses_adm_group_and_permissions(self):
+        self.assertIn(
+            'ExecStartPost=/usr/bin/chown root:adm '
+            '/var/log/ovn/ovn-controller.log\n',
+            ovn_chassis.OVN_CONTROLLER_SYSTEMD_DROPIN_CONTENT,
+        )
+        self.assertIn(
+            'ExecStartPost=/usr/bin/chmod 0640 '
+            '/var/log/ovn/ovn-controller.log\n',
+            ovn_chassis.OVN_CONTROLLER_SYSTEMD_DROPIN_CONTENT,
+        )
+
+    def test_ensure_ovn_controller_dropin_no_change_if_same(self):
+        with tempfile.TemporaryDirectory() as td:
+            dropin_dir = os.path.join(td, 'ovn-controller.service.d')
+            dropin_file = os.path.join(dropin_dir, 'log-perms.conf')
+            os.makedirs(dropin_dir, exist_ok=True)
+            with open(dropin_file, 'w') as fd:
+                fd.write(ovn_chassis.OVN_CONTROLLER_SYSTEMD_DROPIN_CONTENT)
+
+            with mock.patch.object(
+                ovn_chassis,
+                'OVN_CONTROLLER_SYSTEMD_DROPIN_DIR',
+                dropin_dir,
+            ), mock.patch.object(
+                ovn_chassis,
+                'OVN_CONTROLLER_SYSTEMD_DROPIN_FILE',
+                dropin_file,
+            ), mock.patch.object(ovn_chassis, 'write_file') as write_file:
+                changed = self.target._ensure_ovn_controller_dropin()
+
+            self.assertFalse(changed)
+            write_file.assert_not_called()

--- a/unit_tests/test_reactive_ovn_chassis_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_handlers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import reactive.ovn_chassis_handlers as handlers
+import mock
 
 import charms_openstack.test_utils as test_utils
 
@@ -30,9 +31,13 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
             'when_not': {
                 'enable_ovn_chassis_handlers': ('MOCKED_FLAG',),
                 'configure_deferred_restarts': ('is-update-status-hook',),
+                'configure_ovn_controller_log_permissions': (
+                    'is-update-status-hook',),
             },
             'when': {
                 'configure_nrpe': ('config.rendered',),
+                'configure_ovn_controller_log_permissions':
+                    ('config.rendered',),
             },
             'when_any': {
                 'configure_nrpe': ('config.changed.nagios_context',
@@ -52,3 +57,14 @@ class TestOvnHandlers(test_utils.PatchHelper):
         self.patch_object(handlers.reactive, 'set_flag')
         handlers.enable_ovn_chassis_handlers()
         self.set_flag.assert_called_once_with('MOCKED_FLAG')
+
+    def test_configure_ovn_controller_log_permissions(self):
+        self.patch_object(handlers.charm, 'provide_charm_instance')
+        instance = mock.MagicMock()
+        self.provide_charm_instance.return_value.__enter__.return_value = \
+            instance
+
+        handlers.configure_ovn_controller_log_permissions()
+
+        self.provide_charm_instance.assert_called_once_with()
+        instance.configure_ovn_controller_log_permissions.assert_called_once()


### PR DESCRIPTION
Add charm logic to keep /var/log/ovn/ovn-controller.log readable (0644) by:
- inserting 'create 0644 root root' into /etc/logrotate.d/ovn-common when missing
- installing an ovn-controller systemd drop-in to enforce permissions on start