### PR TITLE
build.lock: Update charm-layer-ovn (23.09) to include ovn-monitor-all

### DIFF
--- a/src/build.lock
+++ b/src/build.lock
@@ -45,8 +45,8 @@
       "item": "layer:ovn",
       "url": "https://github.com/openstack-charmers/charm-layer-ovn.git",
       "vcs": null,
-      "branch": "b5c4ae335fac5325ad1e0704ce9ddad818d5206a",
-      "commit": "b5c4ae335fac5325ad1e0704ce9ddad818d5206a"
+      "branch": "b0cee1d3b1bf7e7fc4236d9b2057419d3411771b",
+      "commit": "b0cee1d3b1bf7e7fc4236d9b2057419d3411771b"
     },
     {
       "type": "layer",


### PR DESCRIPTION
New version of charm-layer-ovn that adds the ovn-monitor-all configuration option to the ovn-controller.

Related-Bug: LP 2138758
Signed-off-by: goldberl leah.goldberg@canonical.com