### PR TITLE
Pin setuptools-scm dependency.

### DIFF
--- a/src/wheelhouse-constraints.txt
+++ b/src/wheelhouse-constraints.txt
@@ -1,0 +1,2 @@
+# pinning setuptools-scm due to wheelhouse dependency issue, causing charm build errors.
+setuptools-scm<10.0.0


### PR DESCRIPTION
setuptools-scm is breaking the charm build. In charm-tools a new PR was merged https://github.com/juju/charm-tools/pull/693 which allows specifying wheelhouse constraints as shown in https://github.com/juju/charm-tools/blob/2463e7ad02139215b5c28f4d036313f9ddf392ab/charmtools/build/tactics.py#L1052. Pinning to version <10.0.0 seams sufficient to fix the issue.