### PR TITLE
Charmcraft: bump rust to 1.91.

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,13 +12,13 @@ parts:
     - python3-dev
     - libffi-dev
     - libssl-dev
-    - rustc-1.85
-    - cargo-1.85
+    - rustc-1.91
+    - cargo-1.91
     - pkg-config
     override-build: |
-      # Note(mylesjp): Force build to use rustc-1.85
-      ln -s /usr/bin/rustc-1.85 /usr/bin/rustc
-      ln -s /usr/bin/cargo-1.85 /usr/bin/cargo
+      # Note(mylesjp): Force build to use rustc-1.91
+      ln -s /usr/bin/rustc-1.91 /usr/bin/rustc
+      ln -s /usr/bin/cargo-1.91 /usr/bin/cargo
       craftctl default
     build-snaps:
     - charm/latest/edge
@@ -27,6 +27,7 @@ parts:
     - CHARM_LAYERS_DIR: $CRAFT_PROJECT_DIR/layers/
     - MAKEFLAGS: -j$(nproc)
     - CARGO_HTTP_MULTIPLEXING: 'false'
+    - MATURIN_NO_INSTALL_RUST: "1"
 
 base: ubuntu@24.04
 platforms:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,9 +16,9 @@ parts:
     - cargo-1.85
     - pkg-config
     override-build: |
-      # Note(mylesjp): Force build to use rustc-1.80
-      ln -s /usr/bin/rustc-1.80 /usr/bin/rustc
-      ln -s /usr/bin/cargo-1.80 /usr/bin/cargo
+      # Note(mylesjp): Force build to use rustc-1.85
+      ln -s /usr/bin/rustc-1.85 /usr/bin/rustc
+      ln -s /usr/bin/cargo-1.85 /usr/bin/cargo
       craftctl default
     build-snaps:
     - charm/latest/edge


### PR DESCRIPTION
   There is an inconsistency were the symbolic linking is using 1.80 version of rust, while the installed version is 1.85, basically linking a non existing binary. Since version 1.91 of rust has been released, both were bumped up to 1.91.    
    Finally a environment variable is introduced in order to block maturin from downloading its own rust version, which could override the previously specified one.
    It is preferred to use a rust binary provided by ubuntu archives as we can control its dependencies and have better security guaranties.
