### PR TITLE
Pin rustc and cargo to 1.85

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,8 +13,8 @@ parts:
       - python3-dev
       - libffi-dev
       - libssl-dev
-      - rustc
-      - cargo
+      - rustc-1.85
+      - cargo-1.85
     build-snaps:
       - charm
     build-environment:


### PR DESCRIPTION
The 23.09 Launchpad build (all architectures) started failing because the --use-lock-file-branches flag causes the build.lock to inject rpds_py==0.13.1 and jsonschema==4.20.0 into the wheelhouse. Combined with --binary-wheels-from-source, rpds_py must be compiled from source, which requires maturin as a PEP 517 build dependency. The latest maturin (1.13.1) uses Rust edition 2024, but the unversioned rustc/cargo packages on Jammy provide Cargo 1.75.0, which does not support edition 2024.

Pin build-packages to rustc-1.85 and cargo-1.85 (matching what stable/24.03 already uses) to provide a supported Rust toolchain.